### PR TITLE
Enable parallel.js to transmit transferable objects

### DIFF
--- a/index.html
+++ b/index.html
@@ -97,6 +97,28 @@ r.fetch(yourCallBack);
                 <button class="btn btn-primary">Try it</button>
                 <span class="result"></span>
             </div>
+            <p>You can even transmit transferable objects:</p>
+
+            <div class="example" id="example-5">
+<pre class="prettyprint linenums">
+var sum = function (n) { 
+    var total = 0; 
+    for (var i=0; i < n.length; ++i) {
+        total += n[i];
+    }
+    return total; 
+};
+
+// Spawn a remote reference
+var r = Parallel.spawn(sum, new Uint8Array([1,2,3]));
+
+// Call back when done
+r.fetch(yourCallBack);
+</pre>      
+
+                <button class="btn btn-primary">Try it</button>
+                <span class="result"></span>
+            </div>
 
             <h3 id="mapreduce">Parallel.mapreduce</h3>
 

--- a/js/main.js
+++ b/js/main.js
@@ -27,6 +27,34 @@ $(function () {
         r.fetch(check());
     });
 
+
+    $('#example-5 .btn').click(function () {
+        var that = this;
+
+        var sum = function (n) { 
+            var total = 0; 
+            for (var i=0; i < n.length; ++i) {
+                total += n[i];
+            }
+            return total; 
+        };
+
+        var check = function () {
+            if (!r.fetch()) {
+                $(that).siblings('.result').html('Computation started: ' + Math.floor((Date.now() - start) / 1000) + 's ago');
+            } else {
+                return $(that).siblings('.result').html('Result is: ' + r.fetch() + '. Computed in: ' + Math.floor((Date.now() - start) / 1000) + ' seconds.');
+            }
+
+            setTimeout(check, 10);
+        }
+
+        var start = Date.now();
+        var r = Parallel.spawn(sum, new Uint8Array([1,2,3]));
+
+        r.fetch(check());
+    });
+
     $('#example-3 .btn').click(function () {
         var that = this;
 


### PR DESCRIPTION
This only works in a client side setting because node.js transmits it's values via a socket and therefore string based.

This is necessary to enable developers to transmit Uint8Array contents of a canvas for example. This would be painfully slow to transmit with JSON.

I didn't have anything to test with node.js, although I tried to change as little as possible in that respect.
As for the client side: I added a new example to the index.html file and tested all the available examples successfully.
