### PR TITLE
URL is not available on iOS' webview so use the prefixed window.webkitURL, when necessary.

### DIFF
--- a/lib/parallel.js
+++ b/lib/parallel.js
@@ -141,7 +141,11 @@
 					}
 				} else {
 					var blob = new Blob([src], { type: 'text/javascript' });
-					var url = URL.createObjectURL(blob);
+					var urlClass = (typeof URL === "object") ? URL : window.webkitURL;
+					if(urlClass === undefined){
+						throw new Error('Can\'t use URL or window.webkitURL to create blog URLs');
+					}
+					var url = urlClass.createObjectURL(blob);
 
 					wrk = new Worker(url);
 				}


### PR DESCRIPTION
Preferably this check would only happen once but putting urlClass on 'this' feels nasty.

This could be tested but I'm editing in the browser (quick submission here). Feel free to take this and implement in a better way.

Hope it helps.

FYA: @adambom 
