### PR TITLE
Publish as a bower package

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,17 @@
+{
+  "name": "parallel.js",
+  "version": "0.3.0",
+  "homepage": "https://adambom.github.io/parallel.js/",
+  "authors": [
+    "Adam Savitzky <adam.savitzky@gmail.com>"
+  ],
+  "description": "Parallel.js is a simple library for parallel computing in Javascript, either in Node.js or in the Web Browser. Parallel takes advantage of Web Workers for the web, and child processes for Node.",
+  "license": "BSD",
+  "ignore": [
+    "**/.*",
+    "node_modules",
+    "bower_components",
+    "test",
+    "tests"
+  ]
+}


### PR DESCRIPTION
Hi,

in a current project we want to go in production in the next weeks but Parallel.js 
is the only dependency we include manually. That's why publishing as bower package would be nice. 
See also issue #69.

Things I did:
- added `bower.json` to the project root as described [here](https://github.com/bower/bower#defining-a-package)
- used `0.3.0` as version as the last release was v0.2 - see [here](https://github.com/adambom/parallel.js/releases)

Things to be done to complete the bower register process:
- Review of `bower.json`
- Finally register as bower package ([see this](https://github.com/bower/bower#registering-packages))

Thanks for this nice library!
