### PR TITLE
remove BOM character from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,4 +1,4 @@
-﻿{
+{
 	"name": "paralleljs",
 	"version": "0.2.1",
 	"author": "Adam Savitzky <adam.savitzky@gmail.com>",


### PR DESCRIPTION
This removes a  U+FEFF character at the top of the package.json file.

It causes browserify to complain about an unknown character and kills testling.
