### PR TITLE
Parallel2.js to Parallel.js

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,13 +1,16 @@
-Copyright (c) 2014, Adam Savitzky
+Copyright (c) 2016, Adam Savitzky
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:
+      
     * Redistributions of source code must retain the above copyright
       notice, this list of conditions and the following disclaimer.
+      
     * Redistributions in binary form must reproduce the above copyright
       notice, this list of conditions and the following disclaimer in the
       documentation and/or other materials provided with the distribution.
+      
     * Neither the name of the organization nor the
       names of its contributors may be used to endorse or promote products
       derived from this software without specific prior written permission.


### PR DESCRIPTION
Parallel2.js is now coming back to Parallel.js.

There is nothing more I can see which has not been moved over or superseded in code corrections and updates.

I will leave Parallel2.js up for now, but I might decided to privatise the repository in the future.