### PR TITLE
Added support for terminating a spawned worker if a timeout is reached

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ console.log(p.data); // prints [1, 2, 3, 4, 5]
 
 ---
 
-### `spawn(fn)`
+### `spawn(fn, opts)`
 
 This function will spawn a new process on a worker thread. Pass it the function you want to call. Your
 function will receive one argument, which is the current data. The value returned from your spawned function will
@@ -65,6 +65,8 @@ update the current data.
 **Arguments**
 
 * `fn`: A function to execute on a worker thread. Receives the wrapped data as an argument. The value returned will be assigned to the wrapped data.
+* `opts`: An optional object to pass to spawn.
+* 'opts.timeout': milliseconds to way for function to return value.  If the worker does not finish in this time, it will be killed.
 
 **Example**
 

--- a/lib/parallel.js
+++ b/lib/parallel.js
@@ -190,18 +190,31 @@
   Parallel.prototype.spawn = function(cb, env) {
     const that = this;
     const newOp = new Operation();
+    let timeout;
 
     env = extend(this.options.env, env || {});
 
     this.operation.then(() => {
+
+      if(env.timeout) {
+        timeout = setTimeout(function() {
+          if(!newOp.resolved) {
+            wrk.terminate();
+            newOp.resolve(new Error('Operation timed out!'), null);
+          }
+        }, env.timeout);
+      }
+      
       const wrk = that._spawnWorker(cb, env);
       if (wrk !== undefined) {
         wrk.onmessage = function(msg) {
+          if(timeout) clearTimeout(timeout);
           wrk.terminate();
           that.data = msg.data;
           newOp.resolve(null, that.data);
         };
         wrk.onerror = function(e) {
+          if(timeout) clearTimeout(timeout);
           wrk.terminate();
           newOp.resolve(e, null);
         };


### PR DESCRIPTION
Hi, I found this lib because I was searching for a way to easily spawn a worker, but also be able to terminate it if a timeout is reached.  The use case is that I want to time limit execution for certain operations. 

I don't have any experience with the test frameworks in this lib, but if my pull request looks promising, I'm happy to learn and create a test spec.  But only if you think this extra feature even belongs in parallel.js?  

